### PR TITLE
Change API endpoint URL

### DIFF
--- a/pinnacle/baseclient.py
+++ b/pinnacle/baseclient.py
@@ -14,7 +14,7 @@ class BaseClient(object):
         """
         self.username = username
         self.password = password
-        self.url = 'https://api.pinnaclesports.com/'
+        self.url = 'https://api.pinnacle.com/'
         self.session = requests.Session()
         self.get_password()
 


### PR DESCRIPTION
Can't get SSL connection to https://api.pinnaclesports.com/ from some locations.
Changed it to https://api.pinnacle.com/ (Got it from official R package source) and all work well.