### PR TITLE
Added enum34 so it works in versions of python before 3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.13.0
 python-dateutil==2.6.0
 pytz==2017.2
+enum34==1.1.6


### PR DESCRIPTION
Resolve #3 

I think what was happening with issue #3  is that if you're using a version of python before 3.4, enum module isn't included, so after installing all requirements in requirements.txt you get an error saying enum module not installed. So if you then install the enum modue (which is the natural thing to try), you then the error message that was coming up in issue #3  . However if you install enum34 instead of enum, then it will work. 

Thus including enum34 in requirements.txt prevents this error from occurring.
