### PR TITLE
Enable installation of pinnacle in environment without 'requests'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [metadata]
 description-file = README.md
+version = attr: pinnacle.__version__

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,8 @@
 
 from setuptools import setup, find_packages
-from pinnacle import __version__
 
 setup(
     name="pinnacle",
-    version=__version__,
     author="Rory Cole",
     author_email="rory.cole1990@gmail.com",
     description="Pinnacle API Python wrapper",


### PR DESCRIPTION
First of all, thanks for the clean wrapper library :)

Previously, the setup.py imported the version of the package directory with `from pinnacle import __version__`. The issue with this approach is that when `setup.py` imports from pinnacle package, it ends up trying to also import `requests`.

When installing in a clean python installation, `requests` is not available, thus installing the package is not possible without first installing requests manually.

This method of extracting package version (with the drawbacks) is also listed as one of the possible options in https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version.

This commit changes the versioning to follow a recent note on the same page, by adding the version in the `setup.cfg` file instead.

Only more recent versions of `setuptools` support this (versions after 46.4 which has been released this spring). With older versions of setuptools, the installation of pinnacle package will fail if requests is not installed, as it has been failing up to this point.

Even older versions of setuptools (tested with `setuptools 39.0`, which is the default on ubuntu 18.04) are able to correctly set the package version in `PKG-INFO`during installation even when it is only specified in the `pinnacle.__init__.py` file and not in the `setup.py`at all.

In short, I see no drawbacks, only benefits :).