### PR TITLE
Remove version on pytz.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests==2.13.0
 python-dateutil==2.6.0
-pytz==2017.2
 enum34==1.1.6
+pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.13.0
+requests==2.28.1
 python-dateutil==2.6.0
 enum34==1.1.6
 pytz


### PR DESCRIPTION
Having it locked to 2017.1 produces issues with projects that use another version